### PR TITLE
Fix memleak & use ScheduledExecutorService instead of Timer

### DIFF
--- a/src/main/java/dev/lambdaurora/lambdamap/map/WorldMap.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/map/WorldMap.java
@@ -44,6 +44,8 @@ import org.jetbrains.annotations.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Represents the world map.
@@ -62,6 +64,8 @@ public class WorldMap {
     private final MinecraftClient client = MinecraftClient.getInstance();
     private final File directory;
     private final MarkerManager markerManager;
+
+    final ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor();
 
     private final World world;
 
@@ -369,6 +373,7 @@ public class WorldMap {
     }
 
     public void unload() {
+        this.service.shutdown();
         this.markerManager.save();
         this.chunks.forEach((pos, chunk) -> chunk.unload());
         this.chunks.clear();


### PR DESCRIPTION
Very small change, but prevents memory from being endlessly allocated, and more efficiently uses threads by only using one per world rather than hundreds of timers at minimum.