### PR TITLE
Store maps by world seed to reduce map collisions

### DIFF
--- a/src/main/java/dev/lambdaurora/lambdamap/mixin/BiomeAccessAccessor.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/mixin/BiomeAccessAccessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 LambdAurora <aurora42lambda@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package dev.lambdaurora.lambdamap.mixin;
+
+import net.minecraft.world.biome.source.BiomeAccess;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(BiomeAccess.class)
+public interface BiomeAccessAccessor {
+    @Accessor
+    long getSeed();
+}

--- a/src/main/resources/lambdamap.mixins.json
+++ b/src/main/resources/lambdamap.mixins.json
@@ -3,6 +3,7 @@
   "package": "dev.lambdaurora.lambdamap.mixin",
   "compatibilityLevel": "JAVA_17",
   "client": [
+    "BiomeAccessAccessor",
     "BlockColorsAccessor",
     "ChunkDeltaUpdateS2CPacketAccessor",
     "ClientPlayerInteractionManagerMixin",


### PR DESCRIPTION
Helps players on proxies like BungeeCord or Velocity not have their maps overwritten by other servers on the proxy