### PR TITLE
Fix integer rounding issues for world map; interpolate position in minimap

### DIFF
--- a/src/main/java/dev/lambdaurora/lambdamap/gui/WorldMapRenderer.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/WorldMapRenderer.java
@@ -93,13 +93,13 @@ public class WorldMapRenderer {
         this.scale = 1 << scale;
 
         if (this.worldMap != null) {
-            int x = this.worldMap.getViewX();
-            int z = this.worldMap.getViewZ();
+            double x = this.worldMap.getViewX();
+            double z = this.worldMap.getViewZ();
 
             this.worldMap.updateViewPos(x, z);
 
-            this.cornerViewX = x - (this.scaledWidth() / 2);
-            this.cornerViewZ = z - (this.scaledHeight() / 2);
+            this.cornerViewX = (int) (x - (this.scaledWidth() / 2));
+            this.cornerViewZ = (int) (z - (this.scaledHeight() / 2));
 
             if (this.textureManager != null) {
                 this.textureManager.updateTextures();
@@ -163,11 +163,11 @@ public class WorldMapRenderer {
         return this.height() * this.scale();
     }
 
-    public void updateView(int x, int z) {
+    public void updateView(double x, double z) {
         this.updateView(x, z, false);
     }
 
-    public void updateView(int x, int z, boolean forceUpdate) {
+    public void updateView(double x, double z, boolean forceUpdate) {
         this.worldMap.updateViewPos(x, z);
 
         x -= (this.scaledWidth() / 2);
@@ -176,7 +176,7 @@ public class WorldMapRenderer {
         boolean shouldUpdate = false;
         if (this.cornerViewX != x && this.textureManager != null) {
             int oldChunkX = this.getCornerMapChunkX();
-            int newChunkX = MapChunk.blockToChunk(x);
+            int newChunkX = MapChunk.blockToChunk((int) x);
 
             if (oldChunkX != newChunkX) {
                 int offset = Math.abs(newChunkX - oldChunkX);
@@ -188,7 +188,7 @@ public class WorldMapRenderer {
 
         if (this.cornerViewZ != z && this.textureManager != null) {
             int oldChunkZ = this.getCornerMapChunkZ();
-            int newChunkZ = MapChunk.blockToChunk(z);
+            int newChunkZ = MapChunk.blockToChunk((int) z);
 
             if (oldChunkZ != newChunkZ) {
                 int offset = Math.abs(newChunkZ - oldChunkZ);
@@ -198,8 +198,8 @@ public class WorldMapRenderer {
             }
         }
 
-        this.cornerViewX = x;
-        this.cornerViewZ = z;
+        this.cornerViewX = (int) x;
+        this.cornerViewZ = (int) z;
 
         if (shouldUpdate || forceUpdate)
             this.update();

--- a/src/main/java/dev/lambdaurora/lambdamap/gui/WorldMapWidget.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/WorldMapWidget.java
@@ -72,9 +72,9 @@ public class WorldMapWidget extends AbstractSpruceWidget {
     @Override
     public boolean onNavigation(@NotNull NavigationDirection direction, boolean tab) {
         if (!tab) {
-            int viewX = this.mod.getMap().getViewX();
-            int viewZ = this.mod.getMap().getViewZ();
-            int multiplier = Screen.hasShiftDown() ? 10 : 1;
+            double viewX = this.mod.getMap().getViewX();
+            double viewZ = this.mod.getMap().getViewZ();
+            double multiplier = Screen.hasShiftDown() ? 10 : 1;
             switch (direction) {
                 case LEFT -> this.renderer.updateView(viewX - multiplier, viewZ);
                 case RIGHT -> this.renderer.updateView(viewX + multiplier, viewZ);
@@ -96,13 +96,13 @@ public class WorldMapWidget extends AbstractSpruceWidget {
     @Override
     protected boolean onMouseDrag(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
         if (button == GLFW.GLFW_MOUSE_BUTTON_1) {
-            int viewX = this.mod.getMap().getViewX();
-            int viewZ = this.mod.getMap().getViewZ();
-            float scaleCompensation = 1.f / this.scale;
+            double viewX = this.mod.getMap().getViewX();
+            double viewZ = this.mod.getMap().getViewZ();
+            double scaleCompensation = 1d / this.scale;
             if (this.renderer.scale() != 1) {
                 scaleCompensation = this.renderer.scale();
             }
-            this.renderer.updateView((int) (viewX - deltaX * scaleCompensation), (int) (viewZ - deltaY * scaleCompensation));
+            this.renderer.updateView(viewX - deltaX * scaleCompensation, viewZ - deltaY * scaleCompensation);
             return true;
         }
         return super.onMouseDrag(mouseX, mouseY, button, deltaX, deltaY);

--- a/src/main/java/dev/lambdaurora/lambdamap/map/WorldMap.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/map/WorldMap.java
@@ -70,10 +70,10 @@ public class WorldMap {
 
     private final World world;
 
-    private int viewX = 0;
-    private int viewZ = 0;
-    private int playerViewX = 0;
-    private int playerViewZ = 0;
+    private double viewX = 0;
+    private double viewZ = 0;
+    private double playerViewX = 0;
+    private double playerViewZ = 0;
 
     public WorldMap(World world, File directory) {
         this.directory = directory;
@@ -105,15 +105,15 @@ public class WorldMap {
         return this.getRegistryManager().get(Registry.BIOME_KEY);
     }
 
-    public int getViewX() {
+    public double getViewX() {
         return this.viewX;
     }
 
-    public int getViewZ() {
+    public double getViewZ() {
         return this.viewZ;
     }
 
-    public boolean updateViewPos(int viewX, int viewZ) {
+    public boolean updateViewPos(double viewX, double viewZ) {
         boolean changed = viewX != this.viewX || viewZ != this.viewZ;
         this.viewX = viewX;
         this.viewZ = viewZ;
@@ -355,10 +355,10 @@ public class WorldMap {
         int playerViewEndX = (chunkX + viewDistance) >> 3;
         int playerViewEndZ = (chunkZ + viewDistance) >> 3;
 
-        int viewStartX = this.viewX - VIEW_RANGE;
-        int viewStartZ = this.viewZ - VIEW_RANGE;
-        int viewEndX = this.viewX + VIEW_RANGE;
-        int viewEndZ = this.viewZ + VIEW_RANGE;
+        int viewStartX = (int) (this.viewX - VIEW_RANGE);
+        int viewStartZ = (int) (this.viewZ - VIEW_RANGE);
+        int viewEndX = (int) (this.viewX + VIEW_RANGE);
+        int viewEndZ = (int) (this.viewZ + VIEW_RANGE);
 
         boolean hasViewer = this.viewX != this.playerViewX || this.viewZ != this.playerViewZ;
         this.chunks.values().removeIf(chunk -> {


### PR DESCRIPTION
Due to how GUI scaling works, mouse movements of 1 pixel can be scaled down to 0.5 or less, so when they are truncated to the nearest integer in `WorldMapWidget` they can get ignored. This PR changes the worldmap coordinates to use doubles internally, truncating to integer for rendering.

This PR also makes player motion with the minimap much smoother by calculating the offset between the (block) position of the player when the map was rendered and their current (interpolated, floating-point) position in each frame. It does make the north-locked map look a bit strange at the edges - this could be fixed by scaling up the map and scissoring it to the right size like the normal map; if you want I can PR that change as well.