### PR TITLE
Minimap fixes (North-locked waypoints, update distance, position offset)

### DIFF
--- a/src/main/java/dev/lambdaurora/lambdamap/LambdaMap.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/LambdaMap.java
@@ -86,7 +86,7 @@ public class LambdaMap implements ClientModInitializer {
 
         ClientTickEvents.START_WORLD_TICK.register(world -> {
             var client = MinecraftClient.getInstance();
-            if (this.map.updatePlayerViewPos(client.player.getBlockX(), client.player.getBlockZ())) {
+            if (this.map.updatePlayerViewPos(client.player.getBlockX(), client.player.getBlockZ(), this.hud.getMovementThreshold())) {
                 this.hud.markDirty();
             }
             this.map.tick();

--- a/src/main/java/dev/lambdaurora/lambdamap/map/WorldMap.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/map/WorldMap.java
@@ -120,13 +120,16 @@ public class WorldMap {
         return changed;
     }
 
-    public boolean updatePlayerViewPos(int viewX, int viewZ) {
-        boolean changed = viewX != this.playerViewX || viewZ != this.playerViewZ;
-        this.playerViewX = viewX;
-        this.playerViewZ = viewZ;
-        if (!(client.currentScreen instanceof WorldMapScreen))
-            this.updateViewPos(viewX, viewZ);
-        return changed;
+    public boolean updatePlayerViewPos(int viewX, int viewZ, float threshold) {
+        if (Math.abs(viewX - this.playerViewX) > threshold || Math.abs(viewZ - this.playerViewZ) > threshold) {
+            this.playerViewX = viewX;
+            this.playerViewZ = viewZ;
+            if (!(client.currentScreen instanceof WorldMapScreen))
+                this.updateViewPos(viewX, viewZ);
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
- Changed the scale of the North-locked map to the same as the normal map, centred on the same position
    - Fixes positions of waypoints on North-locked map
    - Fixes border changes from previous position offset changes
- Improved performance by only updating minimap when player has moved a certain threshold distance (31 north-locked, ~4.49 rotated)
- Fixed player position offset on GUI scales greater than 2 by removing useless multiplication