### PR TITLE
Add marker deletion prompt

### DIFF
--- a/src/main/java/dev/lambdaurora/lambdamap/gui/ConfirmDeletionWidget.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/ConfirmDeletionWidget.java
@@ -8,9 +8,8 @@ import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.OrderedText;
-import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
 
 public class ConfirmDeletionWidget extends SpruceContainerWidget {
     private MarkerListWidget.MarkerEntry markerEntry;
@@ -18,10 +17,8 @@ public class ConfirmDeletionWidget extends SpruceContainerWidget {
     public ConfirmDeletionWidget(MarkerTabWidget parent, Position position, int width, int height) {
         super(position, width, height);
         this.setBackground(EmptyBackground.EMPTY_BACKGROUND);
-        SpruceButtonWidget cancelButton = new SpruceButtonWidget(Position.of(this, 10, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 20, 20, new LiteralText("Cancel"), button -> {
-            parent.switchBack();
-        });
-        SpruceButtonWidget deleteButton = new SpruceButtonWidget(Position.of(this, getWidth() / 2 + 10, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 20, 20, new LiteralText("I'm sure"), button -> {
+        SpruceButtonWidget cancelButton = new SpruceButtonWidget(Position.of(this, 10, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 20, 20, new TranslatableText("lambdamap.marker.confirm_deletion.cancel"), button -> parent.switchBack());
+        SpruceButtonWidget deleteButton = new SpruceButtonWidget(Position.of(this, getWidth() / 2 + 10, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 20, 20, new TranslatableText("lambdamap.marker.confirm_deletion.confirm"), button -> {
             this.markerEntry.parent.removeMarker(markerEntry);
             parent.switchBack();
         });
@@ -35,8 +32,10 @@ public class ConfirmDeletionWidget extends SpruceContainerWidget {
 
         VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(Tessellator.getInstance().getBuffer());
 
-        String name = this.markerEntry.marker.getName() == null ? "Unnamed Marker" : this.markerEntry.marker.getName().asString();
-        OrderedText prompt = Text.of("Are you sure you want to delete " + name + "?").asOrderedText();
+        String name = this.markerEntry.marker.getName() == null ? "" : this.markerEntry.marker.getName().asString();
+        OrderedText prompt = new TranslatableText("lambdamap.marker.confirm_deletion.prompt",
+                    name.equals("") ? new TranslatableText("lambdamap.marker.confirm_deletion.prompt.unnamed") : name)
+                .asOrderedText();
 
         DrawableHelper.drawCenteredTextWithShadow(matrices, this.client.textRenderer, prompt, this.getX() + this.getWidth() / 2, this.getHeight() / 3, 0xffffffff);
 

--- a/src/main/java/dev/lambdaurora/lambdamap/gui/ConfirmDeletionWidget.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/ConfirmDeletionWidget.java
@@ -3,15 +3,14 @@ package dev.lambdaurora.lambdamap.gui;
 import dev.lambdaurora.spruceui.Position;
 import dev.lambdaurora.spruceui.background.EmptyBackground;
 import dev.lambdaurora.spruceui.widget.SpruceButtonWidget;
-import dev.lambdaurora.spruceui.widget.SpruceWidget;
 import dev.lambdaurora.spruceui.widget.container.SpruceContainerWidget;
-import dev.lambdaurora.spruceui.widget.container.SpruceParentWidget;
-import net.minecraft.client.render.LightmapTextureManager;
+import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.LiteralText;
-import net.minecraft.util.math.Matrix4f;
+import net.minecraft.text.OrderedText;
+import net.minecraft.text.Text;
 
 public class ConfirmDeletionWidget extends SpruceContainerWidget {
     private MarkerListWidget.MarkerEntry markerEntry;
@@ -19,26 +18,28 @@ public class ConfirmDeletionWidget extends SpruceContainerWidget {
     public ConfirmDeletionWidget(MarkerTabWidget parent, Position position, int width, int height) {
         super(position, width, height);
         this.setBackground(EmptyBackground.EMPTY_BACKGROUND);
-        int x = 25;
         SpruceButtonWidget cancelButton = new SpruceButtonWidget(Position.of(this, 10, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 20, 20, new LiteralText("Cancel"), button -> {
             parent.switchBack();
         });
         SpruceButtonWidget deleteButton = new SpruceButtonWidget(Position.of(this, getWidth() / 2 + 10, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 20, 20, new LiteralText("I'm sure"), button -> {
-            markerEntry.parent.removeMarker(markerEntry);
+            this.markerEntry.parent.removeMarker(markerEntry);
             parent.switchBack();
         });
-        addChild(cancelButton);
-        addChild(deleteButton);
+        this.addChild(cancelButton);
+        this.addChild(deleteButton);
     }
 
     @Override
     protected void renderWidget(MatrixStack matrices, int mouseX, int mouseY, float delta) {
         this.forEach(child -> child.render(matrices, mouseX, mouseY, delta));
-        int light = LightmapTextureManager.pack(15, 15);
+
         VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(Tessellator.getInstance().getBuffer());
-        Matrix4f model = matrices.peek().getPositionMatrix();
-        String name = markerEntry.marker.getName() == null ? "Unnamed" : markerEntry.marker.getName().asString();
-        this.client.textRenderer.draw("Are you sure you want to delete " + name + "?", this.getX() + 15, height / 3.f, 0xffffffff, true, model, immediate, false, 0, light);
+
+        String name = this.markerEntry.marker.getName() == null ? "Unnamed Marker" : this.markerEntry.marker.getName().asString();
+        OrderedText prompt = Text.of("Are you sure you want to delete " + name + "?").asOrderedText();
+
+        DrawableHelper.drawCenteredTextWithShadow(matrices, this.client.textRenderer, prompt, this.getX() + this.getWidth() / 2, this.getHeight() / 3, 0xffffffff);
+
         immediate.draw();
     }
 

--- a/src/main/java/dev/lambdaurora/lambdamap/gui/ConfirmDeletionWidget.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/ConfirmDeletionWidget.java
@@ -17,8 +17,10 @@ public class ConfirmDeletionWidget extends SpruceContainerWidget {
     public ConfirmDeletionWidget(MarkerTabWidget parent, Position position, int width, int height) {
         super(position, width, height);
         this.setBackground(EmptyBackground.EMPTY_BACKGROUND);
-        SpruceButtonWidget cancelButton = new SpruceButtonWidget(Position.of(this, 10, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 20, 20, new TranslatableText("lambdamap.marker.confirm_deletion.cancel"), button -> parent.switchBack());
-        SpruceButtonWidget deleteButton = new SpruceButtonWidget(Position.of(this, getWidth() / 2 + 10, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 20, 20, new TranslatableText("lambdamap.marker.confirm_deletion.confirm"), button -> {
+        int offset = 5;
+        int spacing = 10;
+        SpruceButtonWidget cancelButton = new SpruceButtonWidget(Position.of(this, spacing + offset, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 2 * spacing, 20, new TranslatableText("lambdamap.marker.confirm_deletion.cancel"), button -> parent.switchBack());
+        SpruceButtonWidget deleteButton = new SpruceButtonWidget(Position.of(this, getWidth() / 2 + spacing - offset, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 2 * spacing, 20, new TranslatableText("lambdamap.marker.confirm_deletion.confirm"), button -> {
             this.markerEntry.parent.removeMarker(markerEntry);
             parent.switchBack();
         });

--- a/src/main/java/dev/lambdaurora/lambdamap/gui/ConfirmDeletionWidget.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/ConfirmDeletionWidget.java
@@ -13,42 +13,42 @@ import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
 
 public class ConfirmDeletionWidget extends SpruceContainerWidget {
-    private MarkerListWidget.MarkerEntry markerEntry;
+	private MarkerListWidget.MarkerEntry markerEntry;
 
-    public ConfirmDeletionWidget(MarkerTabWidget parent, Position position, int width, int height) {
-        super(position, width, height);
-        this.setBackground(EmptyBackground.EMPTY_BACKGROUND);
-        int offset = 5;
-        int spacing = 10;
+	public ConfirmDeletionWidget(MarkerTabWidget parent, Position position, int width, int height) {
+		super(position, width, height);
+		this.setBackground(EmptyBackground.EMPTY_BACKGROUND);
+		int offset = 5;
+		int spacing = 10;
 
-        SpruceButtonWidget deleteButton = new SpruceButtonWidget(Position.of(this, spacing + offset, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 2 * spacing, 20, new TranslatableText("lambdamap.marker.confirm_deletion.confirm"), button -> {
-            this.markerEntry.parent.removeMarker(markerEntry);
-            parent.switchBack();
-        });
-        SpruceButtonWidget cancelButton = new SpruceButtonWidget(Position.of(this, getWidth() / 2 + spacing - offset, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 2 * spacing, 20, new TranslatableText("lambdamap.marker.confirm_deletion.cancel"), button -> parent.switchBack());
+		SpruceButtonWidget deleteButton = new SpruceButtonWidget(Position.of(this, spacing + offset, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 2 * spacing, 20, new TranslatableText("lambdamap.marker.confirm_deletion.confirm"), button -> {
+			this.markerEntry.parent.removeMarker(markerEntry);
+			parent.switchBack();
+		});
+		SpruceButtonWidget cancelButton = new SpruceButtonWidget(Position.of(this, getWidth() / 2 + spacing - offset, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 2 * spacing, 20, new TranslatableText("lambdamap.marker.confirm_deletion.cancel"), button -> parent.switchBack());
 
-        this.addChild(deleteButton);
-        this.addChild(cancelButton);
-    }
+		this.addChild(deleteButton);
+		this.addChild(cancelButton);
+	}
 
-    @Override
-    protected void renderWidget(MatrixStack matrices, int mouseX, int mouseY, float delta) {
-        this.forEach(child -> child.render(matrices, mouseX, mouseY, delta));
+	@Override
+	protected void renderWidget(MatrixStack matrices, int mouseX, int mouseY, float delta) {
+		this.forEach(child -> child.render(matrices, mouseX, mouseY, delta));
 
-        VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(Tessellator.getInstance().getBuffer());
+		VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(Tessellator.getInstance().getBuffer());
 
-        String name = this.markerEntry.marker.getName() == null ? "" : this.markerEntry.marker.getName().asString();
-        OrderedText prompt = new TranslatableText("lambdamap.marker.confirm_deletion.prompt",
-                    new TranslatableText("lambdamap.marker.confirm_deletion.prompt.action").formatted(Formatting.RED),
-                    name.equals("") ? new TranslatableText("lambdamap.marker.confirm_deletion.prompt.unnamed") : name)
-                .asOrderedText();
+		String name = this.markerEntry.marker.getName() == null ? "" : this.markerEntry.marker.getName().asString();
+		OrderedText prompt = new TranslatableText("lambdamap.marker.confirm_deletion.prompt",
+				new TranslatableText("lambdamap.marker.confirm_deletion.prompt.action").formatted(Formatting.RED),
+				name.equals("") ? new TranslatableText("lambdamap.marker.confirm_deletion.prompt.unnamed") : name)
+				.asOrderedText();
 
-        DrawableHelper.drawCenteredTextWithShadow(matrices, this.client.textRenderer, prompt, this.getX() + this.getWidth() / 2, this.getHeight() / 3, 0xffffffff);
+		DrawableHelper.drawCenteredTextWithShadow(matrices, this.client.textRenderer, prompt, this.getX() + this.getWidth() / 2, this.getHeight() / 3, 0xffffffff);
 
-        immediate.draw();
-    }
+		immediate.draw();
+	}
 
-    public void setMarkerEntry(MarkerListWidget.MarkerEntry markerEntry) {
-        this.markerEntry = markerEntry;
-    }
+	public void setMarkerEntry(MarkerListWidget.MarkerEntry markerEntry) {
+		this.markerEntry = markerEntry;
+	}
 }

--- a/src/main/java/dev/lambdaurora/lambdamap/gui/ConfirmDeletionWidget.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/ConfirmDeletionWidget.java
@@ -1,0 +1,48 @@
+package dev.lambdaurora.lambdamap.gui;
+
+import dev.lambdaurora.spruceui.Position;
+import dev.lambdaurora.spruceui.background.EmptyBackground;
+import dev.lambdaurora.spruceui.widget.SpruceButtonWidget;
+import dev.lambdaurora.spruceui.widget.SpruceWidget;
+import dev.lambdaurora.spruceui.widget.container.SpruceContainerWidget;
+import dev.lambdaurora.spruceui.widget.container.SpruceParentWidget;
+import net.minecraft.client.render.LightmapTextureManager;
+import net.minecraft.client.render.Tessellator;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.LiteralText;
+import net.minecraft.util.math.Matrix4f;
+
+public class ConfirmDeletionWidget extends SpruceContainerWidget {
+    private MarkerListWidget.MarkerEntry markerEntry;
+
+    public ConfirmDeletionWidget(MarkerTabWidget parent, Position position, int width, int height) {
+        super(position, width, height);
+        this.setBackground(EmptyBackground.EMPTY_BACKGROUND);
+        int x = 25;
+        SpruceButtonWidget cancelButton = new SpruceButtonWidget(Position.of(this, 10, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 20, 20, new LiteralText("Cancel"), button -> {
+            parent.switchBack();
+        });
+        SpruceButtonWidget deleteButton = new SpruceButtonWidget(Position.of(this, getWidth() / 2 + 10, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 20, 20, new LiteralText("I'm sure"), button -> {
+            markerEntry.parent.removeMarker(markerEntry);
+            parent.switchBack();
+        });
+        addChild(cancelButton);
+        addChild(deleteButton);
+    }
+
+    @Override
+    protected void renderWidget(MatrixStack matrices, int mouseX, int mouseY, float delta) {
+        this.forEach(child -> child.render(matrices, mouseX, mouseY, delta));
+        int light = LightmapTextureManager.pack(15, 15);
+        VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(Tessellator.getInstance().getBuffer());
+        Matrix4f model = matrices.peek().getPositionMatrix();
+        String name = markerEntry.marker.getName() == null ? "Unnamed" : markerEntry.marker.getName().asString();
+        this.client.textRenderer.draw("Are you sure you want to delete " + name + "?", this.getX() + 15, height / 3.f, 0xffffffff, true, model, immediate, false, 0, light);
+        immediate.draw();
+    }
+
+    public void setMarkerEntry(MarkerListWidget.MarkerEntry markerEntry) {
+        this.markerEntry = markerEntry;
+    }
+}

--- a/src/main/java/dev/lambdaurora/lambdamap/gui/ConfirmDeletionWidget.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/ConfirmDeletionWidget.java
@@ -10,6 +10,7 @@ import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.OrderedText;
 import net.minecraft.text.TranslatableText;
+import net.minecraft.util.Formatting;
 
 public class ConfirmDeletionWidget extends SpruceContainerWidget {
     private MarkerListWidget.MarkerEntry markerEntry;
@@ -19,13 +20,15 @@ public class ConfirmDeletionWidget extends SpruceContainerWidget {
         this.setBackground(EmptyBackground.EMPTY_BACKGROUND);
         int offset = 5;
         int spacing = 10;
-        SpruceButtonWidget cancelButton = new SpruceButtonWidget(Position.of(this, spacing + offset, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 2 * spacing, 20, new TranslatableText("lambdamap.marker.confirm_deletion.cancel"), button -> parent.switchBack());
-        SpruceButtonWidget deleteButton = new SpruceButtonWidget(Position.of(this, getWidth() / 2 + spacing - offset, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 2 * spacing, 20, new TranslatableText("lambdamap.marker.confirm_deletion.confirm"), button -> {
+
+        SpruceButtonWidget deleteButton = new SpruceButtonWidget(Position.of(this, spacing + offset, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 2 * spacing, 20, new TranslatableText("lambdamap.marker.confirm_deletion.confirm"), button -> {
             this.markerEntry.parent.removeMarker(markerEntry);
             parent.switchBack();
         });
-        this.addChild(cancelButton);
+        SpruceButtonWidget cancelButton = new SpruceButtonWidget(Position.of(this, getWidth() / 2 + spacing - offset, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 2 * spacing, 20, new TranslatableText("lambdamap.marker.confirm_deletion.cancel"), button -> parent.switchBack());
+
         this.addChild(deleteButton);
+        this.addChild(cancelButton);
     }
 
     @Override
@@ -36,6 +39,7 @@ public class ConfirmDeletionWidget extends SpruceContainerWidget {
 
         String name = this.markerEntry.marker.getName() == null ? "" : this.markerEntry.marker.getName().asString();
         OrderedText prompt = new TranslatableText("lambdamap.marker.confirm_deletion.prompt",
+                    new TranslatableText("lambdamap.marker.confirm_deletion.prompt.action").formatted(Formatting.RED),
                     name.equals("") ? new TranslatableText("lambdamap.marker.confirm_deletion.prompt.unnamed") : name)
                 .asOrderedText();
 

--- a/src/main/java/dev/lambdaurora/lambdamap/gui/ConfirmDeletionWidget.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/ConfirmDeletionWidget.java
@@ -5,6 +5,7 @@ import dev.lambdaurora.spruceui.background.EmptyBackground;
 import dev.lambdaurora.spruceui.widget.SpruceButtonWidget;
 import dev.lambdaurora.spruceui.widget.container.SpruceContainerWidget;
 import net.minecraft.client.gui.DrawableHelper;
+import net.minecraft.client.gui.screen.ScreenTexts;
 import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.util.math.MatrixStack;
@@ -21,11 +22,16 @@ public class ConfirmDeletionWidget extends SpruceContainerWidget {
 		int offset = 5;
 		int spacing = 10;
 
-		SpruceButtonWidget deleteButton = new SpruceButtonWidget(Position.of(this, spacing + offset, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 2 * spacing, 20, new TranslatableText("lambdamap.marker.confirm_deletion.confirm"), button -> {
+		int fixedY = this.getHeight() / 3 * 2 - 10;
+		int fixedWidth = this.getWidth() / 2 - 2 * spacing;
+
+		SpruceButtonWidget deleteButton = new SpruceButtonWidget(Position.of(this, spacing + offset, fixedY),
+				fixedWidth, 20, ScreenTexts.PROCEED, button -> {
 			this.markerEntry.parent.removeMarker(markerEntry);
 			parent.switchBack();
 		});
-		SpruceButtonWidget cancelButton = new SpruceButtonWidget(Position.of(this, getWidth() / 2 + spacing - offset, this.getHeight() / 3 * 2 - 10), this.getWidth() / 2 - 2 * spacing, 20, new TranslatableText("lambdamap.marker.confirm_deletion.cancel"), button -> parent.switchBack());
+		SpruceButtonWidget cancelButton = new SpruceButtonWidget(Position.of(this, getWidth() / 2 + spacing - offset, fixedY),
+				fixedWidth, 20, ScreenTexts.CANCEL, button -> parent.switchBack());
 
 		this.addChild(deleteButton);
 		this.addChild(cancelButton);

--- a/src/main/java/dev/lambdaurora/lambdamap/gui/MarkerListWidget.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/MarkerListWidget.java
@@ -93,7 +93,9 @@ public class MarkerListWidget extends SpruceEntryListWidget<MarkerListWidget.Mar
 
 			this.children.add(new SpruceButtonWidget(Position.of(this, this.getWidth() - 24, 2), 20, 20, new LiteralText("X").formatted(Formatting.RED),
 					btn -> {
-						if(GLFW.glfwGetKey(GLFW.glfwGetCurrentContext(), GLFW.GLFW_KEY_LEFT_SHIFT) == GLFW.GLFW_PRESS) {
+						// Force Deletion using SHIFT key to skip the confirmation dialog, might be worth making configurable?
+						if(GLFW.glfwGetKey(GLFW.glfwGetCurrentContext(), GLFW.GLFW_KEY_LEFT_SHIFT) == GLFW.GLFW_PRESS ||
+								GLFW.glfwGetKey(GLFW.glfwGetCurrentContext(), GLFW.GLFW_KEY_RIGHT_SHIFT) == GLFW.GLFW_PRESS) {
 							this.parent.removeMarker(this);
 						} else {
 							parent.parent.promptForDeletion(this);

--- a/src/main/java/dev/lambdaurora/lambdamap/gui/MarkerListWidget.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/MarkerListWidget.java
@@ -47,11 +47,13 @@ import java.util.Iterator;
 import java.util.List;
 
 public class MarkerListWidget extends SpruceEntryListWidget<MarkerListWidget.MarkerEntry> {
-	private final MarkerManager markerManager;
+	protected final MarkerTabWidget parent;
+	protected final MarkerManager markerManager;
 	private int lastIndex = 0;
 
-	public MarkerListWidget(Position position, int width, int height, MarkerManager markerManager) {
+	public MarkerListWidget(MarkerTabWidget parent, Position position, int width, int height, MarkerManager markerManager) {
 		super(position, width, height, 0, MarkerEntry.class);
+		this.parent = parent;
 		this.markerManager = markerManager;
 
 		this.setBackground(EmptyBackground.EMPTY_BACKGROUND);
@@ -68,9 +70,14 @@ public class MarkerListWidget extends SpruceEntryListWidget<MarkerListWidget.Mar
 		this.addEntry(new MarkerEntry(this, marker));
 	}
 
+	public void removeMarker(MarkerEntry entry) {
+		markerManager.removeMarker(entry.marker);
+		removeEntry(entry);
+	}
+
 	public static class MarkerEntry extends SpruceEntryListWidget.Entry implements SpruceParentWidget<SpruceWidget> {
-		private final MarkerListWidget parent;
-		private final Marker marker;
+		protected final MarkerListWidget parent;
+		final Marker marker;
 		private final List<SpruceWidget> children = new ArrayList<>();
 		private @Nullable SpruceWidget focused;
 
@@ -86,8 +93,11 @@ public class MarkerListWidget extends SpruceEntryListWidget<MarkerListWidget.Mar
 
 			this.children.add(new SpruceButtonWidget(Position.of(this, this.getWidth() - 24, 2), 20, 20, new LiteralText("X").formatted(Formatting.RED),
 					btn -> {
-						this.parent.markerManager.removeMarker(this.marker);
-						this.parent.removeEntry(this);
+						if(GLFW.glfwGetKey(GLFW.glfwGetCurrentContext(), GLFW.GLFW_KEY_LEFT_SHIFT) == GLFW.GLFW_PRESS) {
+							this.parent.removeMarker(this);
+						} else {
+							parent.parent.promptForDeletion(this);
+						}
 					}));
 		}
 

--- a/src/main/java/dev/lambdaurora/lambdamap/gui/MarkerTabWidget.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/MarkerTabWidget.java
@@ -3,14 +3,12 @@ package dev.lambdaurora.lambdamap.gui;
 import dev.lambdaurora.lambdamap.LambdaMap;
 import dev.lambdaurora.lambdamap.map.marker.MarkerManager;
 import dev.lambdaurora.spruceui.Position;
-import dev.lambdaurora.spruceui.navigation.NavigationDirection;
 import dev.lambdaurora.spruceui.widget.container.SpruceContainerWidget;
 
 public class MarkerTabWidget extends SpruceContainerWidget {
     private final MarkerListWidget list;
     private final NewMarkerFormWidget newMarkerFormWidget;
     private final ConfirmDeletionWidget confirmDeletionWidget;
-    private boolean promptForDeletion = false;
 
     public MarkerTabWidget(LambdaMap mod, Position position, int width, int height) {
         super(position, width, height);
@@ -18,36 +16,34 @@ public class MarkerTabWidget extends SpruceContainerWidget {
         MarkerManager markers = mod.getMap().getMarkerManager();
 
         int newMarkerFormHeight = width < 480 ? 80 : 40;
-        list = new MarkerListWidget(this, Position.origin(), width, height - newMarkerFormHeight, markers);
-        newMarkerFormWidget = new NewMarkerFormWidget(Position.of(this, 0, list.getHeight()), width, newMarkerFormHeight, markers, list);
-        confirmDeletionWidget = new ConfirmDeletionWidget(this, Position.origin(), width, height);
+        this.list = new MarkerListWidget(this, Position.origin(), width, height - newMarkerFormHeight, markers);
+        this.newMarkerFormWidget = new NewMarkerFormWidget(Position.of(this, 0, list.getHeight()), width, newMarkerFormHeight, markers, list);
+        this.confirmDeletionWidget = new ConfirmDeletionWidget(this, Position.origin(), width, height);
 
-        addChild(list);
-        addChild(newMarkerFormWidget);
-        addChild(confirmDeletionWidget);
-        switchBack();
+        this.addChild(list);
+        this.addChild(newMarkerFormWidget);
+        this.addChild(confirmDeletionWidget);
+        this.switchBack();
     }
 
     public void promptForDeletion(MarkerListWidget.MarkerEntry entry) {
-        this.promptForDeletion = true;
-        list.setVisible(false);
-        newMarkerFormWidget.setVisible(false);
-        confirmDeletionWidget.setVisible(true);
-        confirmDeletionWidget.setMarkerEntry(entry);
+        this.list.setVisible(false);
+        this.newMarkerFormWidget.setVisible(false);
+        this.confirmDeletionWidget.setVisible(true);
+        this.confirmDeletionWidget.setMarkerEntry(entry);
     }
 
     public void switchBack() {
-        this.promptForDeletion = false;
-        list.setVisible(true);
-        newMarkerFormWidget.setVisible(true);
-        confirmDeletionWidget.setVisible(false);
+        this.list.setVisible(true);
+        this.newMarkerFormWidget.setVisible(true);
+        this.confirmDeletionWidget.setVisible(false);
     }
 
     @Override
-    public boolean onNavigation(NavigationDirection direction, boolean tab) {
-        switchBack();
-        return super.onNavigation(direction, tab);
+    public void setFocused(boolean focused) {
+        if(!focused) {
+            this.switchBack();
+        }
+        super.setFocused(focused);
     }
-
-
 }

--- a/src/main/java/dev/lambdaurora/lambdamap/gui/MarkerTabWidget.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/MarkerTabWidget.java
@@ -1,0 +1,53 @@
+package dev.lambdaurora.lambdamap.gui;
+
+import dev.lambdaurora.lambdamap.LambdaMap;
+import dev.lambdaurora.lambdamap.map.marker.MarkerManager;
+import dev.lambdaurora.spruceui.Position;
+import dev.lambdaurora.spruceui.navigation.NavigationDirection;
+import dev.lambdaurora.spruceui.widget.container.SpruceContainerWidget;
+
+public class MarkerTabWidget extends SpruceContainerWidget {
+    private final MarkerListWidget list;
+    private final NewMarkerFormWidget newMarkerFormWidget;
+    private final ConfirmDeletionWidget confirmDeletionWidget;
+    private boolean promptForDeletion = false;
+
+    public MarkerTabWidget(LambdaMap mod, Position position, int width, int height) {
+        super(position, width, height);
+
+        MarkerManager markers = mod.getMap().getMarkerManager();
+
+        int newMarkerFormHeight = width < 480 ? 80 : 40;
+        list = new MarkerListWidget(this, Position.origin(), width, height - newMarkerFormHeight, markers);
+        newMarkerFormWidget = new NewMarkerFormWidget(Position.of(this, 0, list.getHeight()), width, newMarkerFormHeight, markers, list);
+        confirmDeletionWidget = new ConfirmDeletionWidget(this, Position.origin(), width, height);
+
+        addChild(list);
+        addChild(newMarkerFormWidget);
+        addChild(confirmDeletionWidget);
+        switchBack();
+    }
+
+    public void promptForDeletion(MarkerListWidget.MarkerEntry entry) {
+        this.promptForDeletion = true;
+        list.setVisible(false);
+        newMarkerFormWidget.setVisible(false);
+        confirmDeletionWidget.setVisible(true);
+        confirmDeletionWidget.setMarkerEntry(entry);
+    }
+
+    public void switchBack() {
+        this.promptForDeletion = false;
+        list.setVisible(true);
+        newMarkerFormWidget.setVisible(true);
+        confirmDeletionWidget.setVisible(false);
+    }
+
+    @Override
+    public boolean onNavigation(NavigationDirection direction, boolean tab) {
+        switchBack();
+        return super.onNavigation(direction, tab);
+    }
+
+
+}

--- a/src/main/java/dev/lambdaurora/lambdamap/gui/MarkerTabWidget.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/MarkerTabWidget.java
@@ -6,44 +6,44 @@ import dev.lambdaurora.spruceui.Position;
 import dev.lambdaurora.spruceui.widget.container.SpruceContainerWidget;
 
 public class MarkerTabWidget extends SpruceContainerWidget {
-    private final MarkerListWidget list;
-    private final NewMarkerFormWidget newMarkerFormWidget;
-    private final ConfirmDeletionWidget confirmDeletionWidget;
+	private final MarkerListWidget list;
+	private final NewMarkerFormWidget newMarkerFormWidget;
+	private final ConfirmDeletionWidget confirmDeletionWidget;
 
-    public MarkerTabWidget(LambdaMap mod, Position position, int width, int height) {
-        super(position, width, height);
+	public MarkerTabWidget(LambdaMap mod, Position position, int width, int height) {
+		super(position, width, height);
 
-        MarkerManager markers = mod.getMap().getMarkerManager();
+		MarkerManager markers = mod.getMap().getMarkerManager();
 
-        int newMarkerFormHeight = width < 480 ? 80 : 40;
-        this.list = new MarkerListWidget(this, Position.origin(), width, height - newMarkerFormHeight, markers);
-        this.newMarkerFormWidget = new NewMarkerFormWidget(Position.of(this, 0, list.getHeight()), width, newMarkerFormHeight, markers, list);
-        this.confirmDeletionWidget = new ConfirmDeletionWidget(this, Position.origin(), width, height);
+		int newMarkerFormHeight = width < 480 ? 80 : 40;
+		this.list = new MarkerListWidget(this, Position.origin(), width, height - newMarkerFormHeight, markers);
+		this.newMarkerFormWidget = new NewMarkerFormWidget(Position.of(this, 0, list.getHeight()), width, newMarkerFormHeight, markers, list);
+		this.confirmDeletionWidget = new ConfirmDeletionWidget(this, Position.origin(), width, height);
 
-        this.addChild(list);
-        this.addChild(newMarkerFormWidget);
-        this.addChild(confirmDeletionWidget);
-        this.switchBack();
-    }
+		this.addChild(list);
+		this.addChild(newMarkerFormWidget);
+		this.addChild(confirmDeletionWidget);
+		this.switchBack();
+	}
 
-    public void promptForDeletion(MarkerListWidget.MarkerEntry entry) {
-        this.list.setVisible(false);
-        this.newMarkerFormWidget.setVisible(false);
-        this.confirmDeletionWidget.setVisible(true);
-        this.confirmDeletionWidget.setMarkerEntry(entry);
-    }
+	public void promptForDeletion(MarkerListWidget.MarkerEntry entry) {
+		this.list.setVisible(false);
+		this.newMarkerFormWidget.setVisible(false);
+		this.confirmDeletionWidget.setVisible(true);
+		this.confirmDeletionWidget.setMarkerEntry(entry);
+	}
 
-    public void switchBack() {
-        this.list.setVisible(true);
-        this.newMarkerFormWidget.setVisible(true);
-        this.confirmDeletionWidget.setVisible(false);
-    }
+	public void switchBack() {
+		this.list.setVisible(true);
+		this.newMarkerFormWidget.setVisible(true);
+		this.confirmDeletionWidget.setVisible(false);
+	}
 
-    @Override
-    public void setFocused(boolean focused) {
-        if(!focused) {
-            this.switchBack();
-        }
-        super.setFocused(focused);
-    }
+	@Override
+	public void setFocused(boolean focused) {
+		if(!focused) {
+			this.switchBack();
+		}
+		super.setFocused(focused);
+	}
 }

--- a/src/main/java/dev/lambdaurora/lambdamap/gui/WorldMapScreen.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/WorldMapScreen.java
@@ -51,17 +51,7 @@ public class WorldMapScreen extends SpruceScreen {
 		tabs.addTabEntry(new TranslatableText("lambdamap.tabs.world_map"), new TranslatableText("lambdamap.tabs.world_map.description").formatted(Formatting.GRAY),
 				(width, height) -> new WorldMapWidget(Position.origin(), width, height));
 		tabs.addTabEntry(new TranslatableText("lambdamap.tabs.markers"), new TranslatableText("lambdamap.tabs.markers.description").formatted(Formatting.GRAY),
-				(width, height) -> {
-					var containerWidget = new SpruceContainerWidget(Position.origin(), width, height);
-					MarkerManager markers = this.mod.getMap().getMarkerManager();
-
-					int newMarkerFormHeight = width < 480 ? 80 : 40;
-
-					var list = new MarkerListWidget(Position.origin(), width, height - newMarkerFormHeight, markers);
-					containerWidget.addChild(list);
-					containerWidget.addChild(new NewMarkerFormWidget(Position.of(containerWidget, 0, list.getHeight()), width, newMarkerFormHeight, markers, list));
-					return containerWidget;
-				});
+				(width, height) -> new MarkerTabWidget(mod, Position.origin(), width, height));
 		tabs.addTabEntry(new TranslatableText("lambdamap.tabs.config"), new TranslatableText("lambdamap.tabs.config.description").formatted(Formatting.GRAY),
 				this::buildConfigTab);
 	}

--- a/src/main/resources/assets/lambdamap/lang/en_us.json
+++ b/src/main/resources/assets/lambdamap/lang/en_us.json
@@ -13,10 +13,11 @@
   "lambdamap.marker.new.player_pos": "Player Pos",
   "lambdamap.marker.new.x": "X:",
   "lambdamap.marker.new.z": "Z:",
-  "lambdamap.marker.confirm_deletion.prompt": "Are you sure you want to delete %s?",
+  "lambdamap.marker.confirm_deletion.prompt": "Are you sure you want to %s %s?",
+  "lambdamap.marker.confirm_deletion.prompt.action": "permanently delete",
   "lambdamap.marker.confirm_deletion.prompt.unnamed": "Unnamed Marker",
-  "lambdamap.marker.confirm_deletion.cancel": "Cancel",
   "lambdamap.marker.confirm_deletion.confirm": "I'm sure",
+  "lambdamap.marker.confirm_deletion.cancel": "Cancel",
 
   "lambdamap.tabs.config": "Config",
   "lambdamap.tabs.config.description": "Mod configuration",

--- a/src/main/resources/assets/lambdamap/lang/en_us.json
+++ b/src/main/resources/assets/lambdamap/lang/en_us.json
@@ -13,6 +13,10 @@
   "lambdamap.marker.new.player_pos": "Player Pos",
   "lambdamap.marker.new.x": "X:",
   "lambdamap.marker.new.z": "Z:",
+  "lambdamap.marker.confirm_deletion.prompt": "Are you sure you want to delete %s?",
+  "lambdamap.marker.confirm_deletion.prompt.unnamed": "Unnamed Marker",
+  "lambdamap.marker.confirm_deletion.cancel": "Cancel",
+  "lambdamap.marker.confirm_deletion.confirm": "I'm sure",
 
   "lambdamap.tabs.config": "Config",
   "lambdamap.tabs.config.description": "Mod configuration",

--- a/src/main/resources/assets/lambdamap/lang/en_us.json
+++ b/src/main/resources/assets/lambdamap/lang/en_us.json
@@ -16,8 +16,6 @@
   "lambdamap.marker.confirm_deletion.prompt": "Are you sure you want to %s %s?",
   "lambdamap.marker.confirm_deletion.prompt.action": "permanently delete",
   "lambdamap.marker.confirm_deletion.prompt.unnamed": "Unnamed Marker",
-  "lambdamap.marker.confirm_deletion.confirm": "I'm sure",
-  "lambdamap.marker.confirm_deletion.cancel": "Cancel",
 
   "lambdamap.tabs.config": "Config",
   "lambdamap.tabs.config.description": "Mod configuration",


### PR DESCRIPTION
fixes #12.

This PR adds a deletion prompt which prevents unwanted deletions. It can be skipped by holding LSHIFT or RSHIFT when pressing the button to force marker deletion without being prompted.