### PR TITLE
Dramatically improve 1:1 or closer zoom performance in world map

### DIFF
--- a/src/main/java/dev/lambdaurora/lambdamap/LambdaMapConfig.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/LambdaMapConfig.java
@@ -78,7 +78,7 @@ public final class LambdaMapConfig {
 		this.renderBiomeColorsOption = new SpruceCheckboxBooleanOption("lambdamap.config.render_biome_colors",
 				this::shouldRenderBiomeColors, value -> {
 			this.setRenderBiomeColors(value);
-			this.mod.getRenderer().update();
+			this.mod.getRenderer().update(true);
 			this.mod.hud.markDirty();
 		}, null, true);
 		this.showHudOption = new SpruceCheckboxBooleanOption("lambdamap.config.hud.visible",

--- a/src/main/java/dev/lambdaurora/lambdamap/gui/WorldMapRenderer.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/gui/WorldMapRenderer.java
@@ -384,12 +384,12 @@ public class WorldMapRenderer {
 		}
 
 		public void resetCache() {
-			cachedState = 0;
+			this.cachedState = 0;
 		}
 
 		public void update(WorldMap map, int chunkStartX, int chunkStartZ, int scale) {
 			var paramState = Objects.hash(chunkStartX, chunkStartZ, scale);
-			if (cachedState == paramState)
+			if (this.cachedState == paramState)
 				return;
 
 			this.cachedState = paramState;


### PR DESCRIPTION
Fixes tile "conveyor" recycling direction and doesn't redraw tiles every drag tick if the contents haven't changed

Doesn't fix zoom levels further out than 1:1 since the tiles don't "step" at distances that are a multiple of their width when `scale` is > 1, but it doesn't break them either. More work is required to improve performance there.