### PR TITLE
Performance: Only update biomes when a chunk first loads.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ fabric_api_version=7.1.2+0.87.0
 qsl_version=6.1.1
 
 # Mod properties
-mod_version=1.0.0-alpha.1
+mod_version=1.0.0-alpha.2
 maven_group=dev.lambdaurora
 archives_base_name=lambdamap
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ fabric_api_version=7.1.2+0.87.0
 qsl_version=6.1.1
 
 # Mod properties
-mod_version=1.0.0-alpha.2
+mod_version=1.0.0-alpha.1
 maven_group=dev.lambdaurora
 archives_base_name=lambdamap
 

--- a/src/main/java/dev/lambdaurora/lambdamap/LambdaMap.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/LambdaMap.java
@@ -39,6 +39,7 @@ import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.ChunkSectionPos;
 import net.minecraft.world.Heightmap;
 import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.ChunkStatus;
 import net.minecraft.world.chunk.WorldChunk;
 import org.lwjgl.glfw.GLFW;
@@ -236,7 +237,11 @@ public class LambdaMap implements ClientModInitializer, ClientLifecycleEvents.Re
 				}
 
 				var mapColor = searcher.getState().getMapColor(world, searcher.pos);
-				var biome = world.getBiome(searcher.pos);
+				Biome biome = null;
+				if (chunk instanceof WorldChunkExtension extendedChunk && extendedChunk.lambdamap$isBiomeDirty()) {
+					biome = world.getBiome(searcher.pos).value();
+				}
+
 				int shade;
 
 				if (mapColor == MapColor.WATER) {
@@ -263,7 +268,7 @@ public class LambdaMap implements ClientModInitializer, ClientLifecycleEvents.Re
 				lastHeights[xOffset] = searcher.getHeight();
 				int x = mapChunkStartX + xOffset;
 				int z = mapChunkStartZ + zOffset;
-				if (mapChunk.putPixelAndPreserve(x, z, (byte) (mapColor.id * 4 + shade), biome.value(), searcher.getState())) {
+				if (mapChunk.putPixelAndPreserve(x, z, (byte) (mapColor.id * 4 + shade), biome, searcher.getState())) {
 					this.hud.markDirty();
 				}
 			}

--- a/src/main/java/dev/lambdaurora/lambdamap/extension/WorldChunkExtension.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/extension/WorldChunkExtension.java
@@ -19,6 +19,7 @@ package dev.lambdaurora.lambdamap.extension;
 
 public interface WorldChunkExtension {
 	boolean lambdamap$isDirty();
+	boolean lambdamap$isBiomeDirty();
 
 	void lambdamap$markDirty();
 

--- a/src/main/java/dev/lambdaurora/lambdamap/mixin/WorldChunkMixin.java
+++ b/src/main/java/dev/lambdaurora/lambdamap/mixin/WorldChunkMixin.java
@@ -26,10 +26,17 @@ import org.spongepowered.asm.mixin.Unique;
 public class WorldChunkMixin implements WorldChunkExtension {
 	@Unique
 	private boolean lambdamap$dirty;
+	@Unique
+	private boolean lambdamap$biomeDirty = true;
 
 	@Override
 	public boolean lambdamap$isDirty() {
 		return this.lambdamap$dirty;
+	}
+
+	@Override
+	public boolean lambdamap$isBiomeDirty() {
+		return this.lambdamap$biomeDirty;
 	}
 
 	@Override
@@ -40,5 +47,6 @@ public class WorldChunkMixin implements WorldChunkExtension {
 	@Override
 	public void lambdamap$markClean() {
 		this.lambdamap$dirty = false;
+		this.lambdamap$biomeDirty = false;
 	}
 }


### PR DESCRIPTION
Just uses the existing chunk extension for a set-once property and checks it. uses the existing property of `putPixelAndPreserve()` of keeping nulls.